### PR TITLE
Scope the SWIFT_VERSION setting to this Pod only

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -2,8 +2,10 @@ pod 'Highlightr', :git => 'https://github.com/shirakaba/Highlightr.git', :branch
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['SWIFT_VERSION'] = '4.2'
+    if target.name == 'Highlightr'
+      target.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = '4.2'
+      end
     end
   end
 end


### PR DESCRIPTION
Hi!

This plugin looks really interesting, thanks for sharing it with the 🌏!

This PR solves a compatibility issue with any other plugin using Pods that may need a different SWIFT version than the one this plugin forces the entire project to work. This PR will result in the plugin only forcing the SWIFT version of the Pod installed by this plugin.

Thanks,
Eddy